### PR TITLE
Combine rm with apt-get install, use fingerprint for extra security since it cannot be MITM'd

### DIFF
--- a/1.15.2/Dockerfile
+++ b/1.15.2/Dockerfile
@@ -2,17 +2,16 @@ FROM debian:jessie
 
 MAINTAINER Stuart P. Bentley <stuart@testtrack4.com>
 
-ADD http://download.rethinkdb.com/apt/pubkey.gpg /temp/pubkey.gpg
+# Add the RethinkDB repository and public key
+# "RethinkDB Packaging <packaging@rethinkdb.com>" http://download.rethinkdb.com/apt/pubkey.gpg
+RUN apt-key adv --keyserver pgp.mit.edu --recv-keys 1614552E5765227AEC39EFCFA7E00EF33A8F2399
+RUN echo "deb http://download.rethinkdb.com/apt jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 1.15.2~0jessie
 
-# Add the RethinkDB repository and public key
-RUN echo "deb http://download.rethinkdb.com/apt jessie main" > /etc/apt/sources.list.d/rethinkdb.list
-RUN apt-key add /temp/pubkey.gpg && rm /temp/pubkey.gpg
-RUN apt-get update && apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION
-
-# Remove package lists for size
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
 
 VOLUME ["/data"]
 


### PR DESCRIPTION
So we grab the key and add the apt sources before the `ENV` version to help with docker caching.  We use the key fingerprint to provide a layer of security to the images. Moved the `rm` so that it is in the same layer as the `update` and can be actually removed rather than just a whiteout layer and still taking up space.

Feel free to apply it to the rest of the versions or I can update this PR as well.
