### PR TITLE
Remove stuartpb-specific stuff from update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,25 +8,24 @@ https://github.com/docker-library/docs/blob/master/rethinkdb/README.md
 
 ## Procedure for updating
 
-This is mostly a checklist for my own personal use.
-
-1. Realize RethinkDB has updated. *This part needs improving.*
-2. Go to https://ide.c9.io/stuartpb/rethinkdb-dockerfiles and open a terminal.
-2. Look up what the new package names are by going to
-   http://download.rethinkdb.com/apt/pool/jessie/main/r/rethinkdb/ and
-   http://download.rethinkdb.com/apt/pool/trusty/main/r/rethinkdb/ etc.
-3. Run `./cut-new-release.sh` for each missing release:
+After creating a commit for the new release package using `./cut-new-release.sh`:
 
    ```bash
+   # example
    ./cut-new-release.sh 1.16.1
-   ./cut-new-release.sh 1.16.2 +1
-   # etc...
+   
+   # if package version includes a suffix like "+1",
+   # pass that suffix as the second argument
+   ./cut-new-release.sh 1.16.2 +1 
    ```
 
-4. Commit this, push it to GitHub, and note the hash.
-5. Go to https://github.com/docker-library/official-images/edit/master/library/rethinkdb
-   and put together a pull request that includes all the new tags from jessie.
-6. Wait for that pull request to be approved.
-7. Open up https://ide.c9.io/stuartpb/plushu and update
-   `services/rethinkdb/docker/DEFAULT_IMAGE`. Git commit and push.
-8. Update on any server I care about having the latest RDB on.
+Note the hash of the commit and push it to GitHub.
+
+Once the commit is pushed, go to https://github.com/docker-library/official-images/edit/master/library/rethinkdb
+and put together a pull request that includes all the new tags, using the
+`jessie` dockerfiles. The new point release should be added as a tag, and
+tags for the minor and major versions should be either created or updated
+to point to the new Dockerfile, as well as the "latest" tag.
+
+Once the pull request for the new image is accepted by the upstream Docker
+library, this should be announced in Slack and/or IRC (and maybe Twitter).

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ After creating a commit for the new release package using `./cut-new-release.sh`
 Note the hash of the commit and push it to GitHub.
 
 Once the commit is pushed, go to https://github.com/docker-library/official-images/edit/master/library/rethinkdb
-and put together a pull request that includes all the new tags, using the
-`jessie` dockerfiles. The new point release should be added as a tag, and
-tags for the minor and major versions should be either created or updated
-to point to the new Dockerfile, as well as the "latest" tag.
+and put together a pull request, replacing the old tip-commit hash with the
+new tip-commit hash for all images, and adding new tags for the new version
+(using the `jessie` dockerfiles). The new point release should be added as
+a tag, and tags for the minor and major versions should be either created
+or updated to point to the new Dockerfile, as well as the "latest" tag.
 
 Once the pull request for the new image is accepted by the upstream Docker
 library, this should be announced in Slack and/or IRC (and maybe Twitter).


### PR DESCRIPTION
Here's my proposed flow for RethinkDB pushing a new release. It's basically the same flow as I followed, minus the part where I update my own systems.