### PR TITLE
Fail on empty

### DIFF
--- a/cut-new-release.sh
+++ b/cut-new-release.sh
@@ -4,6 +4,11 @@ base=2.0.1
 new=$1
 suffix=$2
 
+if [[ -z "$1" ]]; then
+  echo "cut-new-release: tag not specified" >&2
+  exit 1
+fi
+
 for distro in jessie trusty utopic wheezy vivid; do
   mkdir "./$distro/$new"
   sed -e "s/$base/$new$suffix/" "./$distro/$base/Dockerfile" \


### PR DESCRIPTION
This prevents creating bogus commits like 070e882.