### PR TITLE
Resolves "Alpine version of container #32"

### DIFF
--- a/alpine/2.3.6/Dockerfile
+++ b/alpine/2.3.6/Dockerfile
@@ -1,0 +1,15 @@
+# Only alpine version that suports rethinkdb is edge
+FROM alpine:edge
+
+ENV RETHINKDB_VERSION 2.3.6-r1
+
+RUN apk add --no-cache \
+    rethinkdb=$RETHINKDB_VERSION
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+EXPOSE 28015 29015 8080
+
+CMD ["rethinkdb", "--bind", "all"]


### PR DESCRIPTION
Creates Dockerfile for an Alpine version of RethinkDB.

The result image is almost 4x smaller then original RethinkDB image:
![image](https://user-images.githubusercontent.com/8144779/29934775-c879fc92-8e52-11e7-8edc-c6cce8bd43b4.png)

resolve #32 