### PR TITLE
Rethinkdb 2.3.6 Alpine version

### DIFF
--- a/alpine/2.3.6/Dockerfile
+++ b/alpine/2.3.6/Dockerfile
@@ -1,10 +1,10 @@
 FROM       alpine
-LABEL      mantainer="Slava Kalashnikov <xemuliam@gmail.com>"
+LABEL      mantainer="Daniel Alan Miller <dalanmiller@rethinkdb.com>"
 ARG        RETHINKDB_PACKAGE_VERSION=2.3.6-r6
 RUN        apk add --no-cache \
                jq \
                rethinkdb=$RETHINKDB_VERSION
-EXPOSE     28015 29015 8080
-VOLUME     /data
+VOLUME     ["/data"]
 WORKDIR    /data
-CMD       rethinkdb --bind all
+CMD        ["rethinkdb", "--bind", "all"]
+EXPOSE     28015 29015 8080

--- a/alpine/2.3.6/Dockerfile
+++ b/alpine/2.3.6/Dockerfile
@@ -1,6 +1,6 @@
 FROM       alpine
 LABEL      mantainer="Daniel Alan Miller <dalanmiller@rethinkdb.com>"
-ARG        RETHINKDB_PACKAGE_VERSION=2.3.6-r6
+ENV        RETHINKDB_PACKAGE_VERSION=2.3.6-r6
 RUN        apk add --no-cache \
                jq \
                rethinkdb=$RETHINKDB_VERSION

--- a/alpine/2.3.6/Dockerfile
+++ b/alpine/2.3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM       alpine
+FROM       alpine:3.8
 LABEL      mantainer="Daniel Alan Miller <dalanmiller@rethinkdb.com>"
 ENV        RETHINKDB_PACKAGE_VERSION=2.3.6-r6
 RUN        apk add --no-cache \

--- a/alpine/2.3.6/Dockerfile
+++ b/alpine/2.3.6/Dockerfile
@@ -1,0 +1,10 @@
+FROM       alpine
+LABEL      mantainer="Slava Kalashnikov <xemuliam@gmail.com>"
+ARG        RETHINKDB_VERSION=2.3.6-r6
+RUN        apk add --no-cache \
+               jq \
+               rethinkdb=$RETHINKDB_VERSION
+EXPOSE     28015 29015 8080
+VOLUME     /data
+WORKDIR    /data
+CMD       rethinkdb --bind all

--- a/alpine/2.3.6/Dockerfile
+++ b/alpine/2.3.6/Dockerfile
@@ -1,6 +1,6 @@
 FROM       alpine
 LABEL      mantainer="Slava Kalashnikov <xemuliam@gmail.com>"
-ARG        RETHINKDB_VERSION=2.3.6-r6
+ARG        RETHINKDB_PACKAGE_VERSION=2.3.6-r6
 RUN        apk add --no-cache \
                jq \
                rethinkdb=$RETHINKDB_VERSION

--- a/alpine/2.3.6/Dockerfile
+++ b/alpine/2.3.6/Dockerfile
@@ -3,7 +3,7 @@ LABEL      mantainer="Daniel Alan Miller <dalanmiller@rethinkdb.com>"
 ENV        RETHINKDB_PACKAGE_VERSION=2.3.6-r6
 RUN        apk add --no-cache \
                jq \
-               rethinkdb=$RETHINKDB_VERSION
+               rethinkdb=$RETHINKDB_PACKAGE_VERSION
 VOLUME     ["/data"]
 WORKDIR    /data
 CMD        ["rethinkdb", "--bind", "all"]


### PR DESCRIPTION
Alpine-linux based Docker image for RethinkDb 2.3.6

Latest Alpine linux image + native Alpine package for RethinkDb.
jq package is also added to be able to easily work with JSON data on RethinkDB host if required.
All settings are completely similar to original Debian-based image, however Alpine-based final image size is 3+ times less than original.