### PR TITLE
Add docker support for 2.3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,28 @@ Dockerfiles for past and present versions of RethinkDB.
 
 https://github.com/docker-library/docs/blob/master/rethinkdb/README.md
 
+## Currently supported distributions
+
+The following base images are supported for containerized RethinkDB servers.
+
+* Ubuntu Xenial
+* Ubuntu Bionic
+* Ubuntu Disco
+* Ubuntu Eoan
+* CentOs 7
+* CentOs 8
+
 ## Procedure for updating
 
 After creating a commit for the new release package using `./cut-new-release.sh`:
 
    ```bash
    # example
-   ./cut-new-release.sh 1.16.1
-   
+   ./cut-new-release.sh 2.3.7
+
    # if package version includes a suffix like "+1",
    # pass that suffix as the second argument
-   ./cut-new-release.sh 1.16.2 +1 
+   ./cut-new-release.sh 2.3.7 +1
    ```
 
 Note the hash of the commit and push it to GitHub.

--- a/bionic/2.3.7/Dockerfile
+++ b/bionic/2.3.7/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:bionic
+
+MAINTAINER Gabor Boros <gabor.brs@gmail.com>
+ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0bionic
+
+
+RUN apt -qqy update \
+    && apt install -y --no-install-recommends ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --fetch-keys https://download.rethinkdb.com/apt/pubkey.gpg \
+    && echo "deb http://download.rethinkdb.com/apt bionic main" > /etc/apt/sources.list.d/rethinkdb.list
+
+RUN apt -qqy update \
+	&& apt install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080

--- a/bionic/2.3.7/Dockerfile
+++ b/bionic/2.3.7/Dockerfile
@@ -1,15 +1,13 @@
 FROM ubuntu:bionic
 
-MAINTAINER Gabor Boros <gabor.brs@gmail.com>
-ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0bionic
-
-
 RUN apt -qqy update \
     && apt install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --fetch-keys https://download.rethinkdb.com/apt/pubkey.gpg \
-    && echo "deb http://download.rethinkdb.com/apt bionic main" > /etc/apt/sources.list.d/rethinkdb.list
+RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1D85E93F801BB43F \
+    && echo "deb https://download.rethinkdb.com/apt bionic main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0bionic
 
 RUN apt -qqy update \
 	&& apt install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \

--- a/centos7/2.3.7/Dockerfile
+++ b/centos7/2.3.7/Dockerfile
@@ -1,0 +1,18 @@
+FROM centos:7
+
+MAINTAINER Gabor Boros <gabor.brs@gmail.com>
+ENV RETHINKDB_PACKAGE_VERSION 2.3.7
+
+RUN curl -L https://download.rethinkdb.com/centos/7/`uname -m`/rethinkdb.repo > /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/centos7/2.3.7/Dockerfile
+++ b/centos7/2.3.7/Dockerfile
@@ -1,9 +1,8 @@
 FROM centos:7
 
-MAINTAINER Gabor Boros <gabor.brs@gmail.com>
-ENV RETHINKDB_PACKAGE_VERSION 2.3.7
-
 RUN curl -L https://download.rethinkdb.com/centos/7/`uname -m`/rethinkdb.repo > /etc/yum.repos.d/rethinkdb.repo
+
+ENV RETHINKDB_PACKAGE_VERSION 2.3.7
 
 RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
 	&& yum clean all

--- a/centos8/2.3.7/Dockerfile
+++ b/centos8/2.3.7/Dockerfile
@@ -1,9 +1,8 @@
 FROM centos:8
 
-MAINTAINER Gabor Boros <gabor.brs@gmail.com>
-ENV RETHINKDB_PACKAGE_VERSION 2.3.7
-
 RUN curl -L https://download.rethinkdb.com/centos/8/`uname -m`/rethinkdb.repo > /etc/yum.repos.d/rethinkdb.repo
+
+ENV RETHINKDB_PACKAGE_VERSION 2.3.7
 
 RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
 	&& yum clean all

--- a/centos8/2.3.7/Dockerfile
+++ b/centos8/2.3.7/Dockerfile
@@ -1,0 +1,18 @@
+FROM centos:8
+
+MAINTAINER Gabor Boros <gabor.brs@gmail.com>
+ENV RETHINKDB_PACKAGE_VERSION 2.3.7
+
+RUN curl -L https://download.rethinkdb.com/centos/8/`uname -m`/rethinkdb.repo > /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/cut-new-release.sh
+++ b/cut-new-release.sh
@@ -1,19 +1,38 @@
 #! /usr/bin/env bash
 
-base=2.3.6
-new=$1
-suffix=$2
+BASE_VERSION=2.3.6
+NEW_VERSION=$1
+SUFFIX=$2
+
+# NOTE: Xenial and CentOS 7 are disabled until we upload 2.3.7
+# packages for them to downloads.rethinkdb.com
+# DISTROS="xenial bionic disco eoan centos7 centos8"
+DISTROS="bionic disco eoan centos8"
+
+function bootstrap_and_build {
+  for DISTRO in $DISTROS; do
+    if [ -d "$DISTRO/$NEW_VERSION" ]; then 
+      echo "$DISTRO/$NEW_VERSION already exists... Skipping Dockerfile bootstrap"
+    elif [ -f "$DISTRO/$BASE_VERSION/Dockerfile" ]; then
+      mkdir "./$DISTRO/$NEW_VERSION"
+      sed -e "s/$BASE_VERSION/$NEW_VERSION$SUFFIX/" "./$DISTRO/$BASE_VERSION/Dockerfile" \
+        >"./$DISTRO/$NEW_VERSION/Dockerfile"
+    fi
+
+    docker build --no-cache -t rethinkdb:$DISTRO-$NEW_VERSION$SUFFIX $DISTRO/$NEW_VERSION$SUFFIX
+  done
+}
+
+function commit_and_tag {
+  git add ./*/"$NEW_VERSION"
+  git commit -m "Add $NEW_VERSION"
+  git tag "$NEW_VERSION" -m "$NEW_VERSION"
+}
 
 if [[ -z "$1" ]]; then
-  echo "cut-new-release: tag not specified" >&2
+  echo "cut-NEW_VERSION-release: tag not specified" >&2
   exit 1
 fi
 
-for distro in jessie stretch trusty utopic vivid wily xenial; do
-  mkdir "./$distro/$new"
-  sed -e "s/$base/$new$suffix/" "./$distro/$base/Dockerfile" \
-    >"./$distro/$new/Dockerfile"
-done
-git add ./*/"$new"
-git commit -m "Add $new"
-git tag "$new" -m "$new"
+bootstrap_and_build;
+commit_and_tag;

--- a/disco/2.3.7/Dockerfile
+++ b/disco/2.3.7/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:disco
+
+MAINTAINER Gabor Boros <gabor.brs@gmail.com>
+ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0disco
+
+
+RUN apt -qqy update \
+    && apt install -y --no-install-recommends ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --fetch-keys https://download.rethinkdb.com/apt/pubkey.gpg \
+    && echo "deb https://download.rethinkdb.com/apt disco main" > /etc/apt/sources.list.d/rethinkdb.list
+
+RUN apt -qqy update \
+	&& apt install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080

--- a/disco/2.3.7/Dockerfile
+++ b/disco/2.3.7/Dockerfile
@@ -1,15 +1,13 @@
 FROM ubuntu:disco
 
-MAINTAINER Gabor Boros <gabor.brs@gmail.com>
-ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0disco
-
-
 RUN apt -qqy update \
     && apt install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --fetch-keys https://download.rethinkdb.com/apt/pubkey.gpg \
+RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1D85E93F801BB43F \
     && echo "deb https://download.rethinkdb.com/apt disco main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0disco
 
 RUN apt -qqy update \
 	&& apt install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \

--- a/eoan/2.3.7/Dockerfile
+++ b/eoan/2.3.7/Dockerfile
@@ -1,15 +1,13 @@
 FROM ubuntu:eoan
 
-MAINTAINER Gabor Boros <gabor.brs@gmail.com>
-ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0eoan
-
-
 RUN apt -qqy update \
     && apt install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --fetch-keys https://download.rethinkdb.com/apt/pubkey.gpg \
+RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1D85E93F801BB43F \
     && echo "deb http://download.rethinkdb.com/apt eoan main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0eoan
 
 RUN apt -qqy update \
 	&& apt install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \

--- a/eoan/2.3.7/Dockerfile
+++ b/eoan/2.3.7/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:eoan
+
+MAINTAINER Gabor Boros <gabor.brs@gmail.com>
+ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0eoan
+
+
+RUN apt -qqy update \
+    && apt install -y --no-install-recommends ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --fetch-keys https://download.rethinkdb.com/apt/pubkey.gpg \
+    && echo "deb http://download.rethinkdb.com/apt eoan main" > /etc/apt/sources.list.d/rethinkdb.list
+
+RUN apt -qqy update \
+	&& apt install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080

--- a/xenial/2.3.6/Dockerfile
+++ b/xenial/2.3.6/Dockerfile
@@ -1,16 +1,13 @@
 FROM ubuntu:xenial
 
-MAINTAINER Gabor Boros <gabor.brs@gmail.com>
-ENV RETHINKDB_PACKAGE_VERSION 2.3.6~0xenial
-
-
 RUN apt-get update -qq \
-    && apt-get install -y --no-install-recommends \
-        apt-transport-https ca-certificates curl gnupg-curl gnupg2 \
+    && apt-get install -y --no-install-recommends apt-transport-https ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --fetch-keys https://download.rethinkdb.com/apt/pubkey.gpg \
+RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1D85E93F801BB43F \
     && echo "deb https://download.rethinkdb.com/apt xenial main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.3.6~0xenial
 
 RUN apt-get update -qq \
 	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \

--- a/xenial/2.3.6/Dockerfile
+++ b/xenial/2.3.6/Dockerfile
@@ -1,15 +1,18 @@
 FROM ubuntu:xenial
 
-MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
-
-# Add the RethinkDB repository and public key
-# "RethinkDB Packaging <packaging@rethinkdb.com>" http://download.rethinkdb.com/apt/pubkey.gpg
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 3B87619DF812A63A8C1005C30742918E5C8DA04A
-RUN echo "deb http://download.rethinkdb.com/apt xenial main" > /etc/apt/sources.list.d/rethinkdb.list
-
+MAINTAINER Gabor Boros <gabor.brs@gmail.com>
 ENV RETHINKDB_PACKAGE_VERSION 2.3.6~0xenial
 
-RUN apt-get update \
+
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
+        apt-transport-https ca-certificates curl gnupg-curl gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --fetch-keys https://download.rethinkdb.com/apt/pubkey.gpg \
+    && echo "deb https://download.rethinkdb.com/apt xenial main" > /etc/apt/sources.list.d/rethinkdb.list
+
+RUN apt-get update -qq \
 	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Distributing RethinkDB 2.3.7 for Bionic, Disco, Eoan and CentOS 8 base images. Xenial and CentOS 7 is coming in a few days.

(Although the Dockerfile is prepared for CentOS 7, the package is not uploaded to the download server)

The image sizes are the following:
```bash
centos8-2.3.7         aadba3001f97        15 seconds ago          282MB
eoan-2.3.7            5e4898ba3579        54 seconds ago          136MB
disco-2.3.7           81e858a3bd23        About a minute ago      134MB
bionic-2.3.7          3a3b748b64c0        About a minute ago      126MB
```