### PR TITLE
fix: update keyservers

### DIFF
--- a/bionic/2.3.7/Dockerfile
+++ b/bionic/2.3.7/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-bionic bionic main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0bionic

--- a/bionic/2.4.0/Dockerfile
+++ b/bionic/2.4.0/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-bionic bionic main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0bionic

--- a/bionic/2.4.1/Dockerfile
+++ b/bionic/2.4.1/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-bionic bionic main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.1~0bionic

--- a/buster/2.4.0/Dockerfile
+++ b/buster/2.4.0/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/debian-buster buster main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0buster

--- a/buster/2.4.1/Dockerfile
+++ b/buster/2.4.1/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/debian-buster buster main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.1~0buster

--- a/disco/2.3.7/Dockerfile
+++ b/disco/2.3.7/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-disco disco main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0disco

--- a/disco/2.4.0/Dockerfile
+++ b/disco/2.4.0/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-disco disco main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0disco

--- a/disco/2.4.1/Dockerfile
+++ b/disco/2.4.1/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-disco disco main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.1~0disco

--- a/eoan/2.3.7/Dockerfile
+++ b/eoan/2.3.7/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-eoan eoan main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.7~0eoan

--- a/eoan/2.4.0/Dockerfile
+++ b/eoan/2.4.0/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-eoan eoan main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0eoan

--- a/eoan/2.4.1/Dockerfile
+++ b/eoan/2.4.1/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-eoan eoan main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.1~0eoan

--- a/focal/2.4.0/Dockerfile
+++ b/focal/2.4.0/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-focal focal main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0focal

--- a/focal/2.4.1/Dockerfile
+++ b/focal/2.4.1/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-focal focal main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.1~0focal

--- a/jessie/1.15.1/Dockerfile
+++ b/jessie/1.15.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 1.15.1~0jessie

--- a/jessie/1.15.2/Dockerfile
+++ b/jessie/1.15.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 1.15.2~0jessie

--- a/jessie/1.15.3/Dockerfile
+++ b/jessie/1.15.3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 1.15.3~0jessie

--- a/jessie/1.16.0/Dockerfile
+++ b/jessie/1.16.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 1.16.0+1~0jessie

--- a/jessie/1.16.1/Dockerfile
+++ b/jessie/1.16.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 1.16.1~0jessie

--- a/jessie/1.16.2/Dockerfile
+++ b/jessie/1.16.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 1.16.2+1~0jessie

--- a/jessie/1.16.3/Dockerfile
+++ b/jessie/1.16.3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 1.16.3~0jessie

--- a/jessie/2.0.0/Dockerfile
+++ b/jessie/2.0.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.0.0+1~0jessie

--- a/jessie/2.0.1/Dockerfile
+++ b/jessie/2.0.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.0.1~0jessie

--- a/jessie/2.0.2/Dockerfile
+++ b/jessie/2.0.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.0.2~0jessie

--- a/jessie/2.0.3/Dockerfile
+++ b/jessie/2.0.3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.0.3~0jessie

--- a/jessie/2.0.4/Dockerfile
+++ b/jessie/2.0.4/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.0.4~0jessie

--- a/jessie/2.1.0/Dockerfile
+++ b/jessie/2.1.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.1.0+1~0jessie

--- a/jessie/2.1.1/Dockerfile
+++ b/jessie/2.1.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.1.1~0jessie

--- a/jessie/2.1.2/Dockerfile
+++ b/jessie/2.1.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.1.2~0jessie

--- a/jessie/2.1.3/Dockerfile
+++ b/jessie/2.1.3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.1.3~0jessie

--- a/jessie/2.1.4/Dockerfile
+++ b/jessie/2.1.4/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.1.4~0jessie

--- a/jessie/2.1.5/Dockerfile
+++ b/jessie/2.1.5/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.1.5+2~0jessie

--- a/jessie/2.1.6/Dockerfile
+++ b/jessie/2.1.6/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.1.6+1~0jessie

--- a/jessie/2.2.0/Dockerfile
+++ b/jessie/2.2.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.0~0jessie

--- a/jessie/2.2.1/Dockerfile
+++ b/jessie/2.2.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.1~0jessie

--- a/jessie/2.2.2/Dockerfile
+++ b/jessie/2.2.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.2~0jessie

--- a/jessie/2.2.3/Dockerfile
+++ b/jessie/2.2.3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.3+1~0jessie

--- a/jessie/2.2.4/Dockerfile
+++ b/jessie/2.2.4/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.4~0jessie

--- a/jessie/2.2.5/Dockerfile
+++ b/jessie/2.2.5/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.5~0jessie

--- a/jessie/2.2.6/Dockerfile
+++ b/jessie/2.2.6/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.6~0jessie

--- a/jessie/2.3.0/Dockerfile
+++ b/jessie/2.3.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.0~0jessie

--- a/jessie/2.3.1/Dockerfile
+++ b/jessie/2.3.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.1~0jessie

--- a/jessie/2.3.2/Dockerfile
+++ b/jessie/2.3.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.2~0jessie

--- a/jessie/2.3.3/Dockerfile
+++ b/jessie/2.3.3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.3~0jessie

--- a/jessie/2.3.4/Dockerfile
+++ b/jessie/2.3.4/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.4~0jessie

--- a/jessie/2.3.5/Dockerfile
+++ b/jessie/2.3.5/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.5~0jessie

--- a/jessie/2.3.6/Dockerfile
+++ b/jessie/2.3.6/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 3B87619DF812A63A8C1005C30742918E5C8DA04A
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B87619DF812A63A8C1005C30742918E5C8DA04A
 RUN echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.6~0jessie

--- a/jessie/2.4.0/Dockerfile
+++ b/jessie/2.4.0/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0jessie

--- a/jessie/2.4.1/Dockerfile
+++ b/jessie/2.4.1/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.1~0jessie

--- a/stretch/2.1.6/Dockerfile
+++ b/stretch/2.1.6/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.1.6+1~0stretch

--- a/stretch/2.2.0/Dockerfile
+++ b/stretch/2.2.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.0~0stretch

--- a/stretch/2.2.1/Dockerfile
+++ b/stretch/2.2.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.1~0stretch

--- a/stretch/2.2.2/Dockerfile
+++ b/stretch/2.2.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.2~0stretch

--- a/stretch/2.2.3/Dockerfile
+++ b/stretch/2.2.3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.3+1~0stretch

--- a/stretch/2.2.4/Dockerfile
+++ b/stretch/2.2.4/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.4~0stretch

--- a/stretch/2.2.5/Dockerfile
+++ b/stretch/2.2.5/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.5~0stretch

--- a/stretch/2.2.6/Dockerfile
+++ b/stretch/2.2.6/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.2.6~0stretch

--- a/stretch/2.3.0/Dockerfile
+++ b/stretch/2.3.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.0~0stretch

--- a/stretch/2.4.0/Dockerfile
+++ b/stretch/2.4.0/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends apt-transport-https dirmngr ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0stretch

--- a/stretch/2.4.1/Dockerfile
+++ b/stretch/2.4.1/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends apt-transport-https dirmngr ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.1~0stretch

--- a/trusty/2.3.6/Dockerfile
+++ b/trusty/2.3.6/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-trusty trusty main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.6~0trusty

--- a/trusty/2.4.0/Dockerfile
+++ b/trusty/2.4.0/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-trusty trusty main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0trusty

--- a/trusty/2.4.1/Dockerfile
+++ b/trusty/2.4.1/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-trusty trusty main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.1~0trusty

--- a/xenial/2.3.1/Dockerfile
+++ b/xenial/2.3.1/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/ubuntu-xenial xenial main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.1~0xenial

--- a/xenial/2.3.2/Dockerfile
+++ b/xenial/2.3.2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/ubuntu-xenial xenial main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.2~0xenial

--- a/xenial/2.3.3/Dockerfile
+++ b/xenial/2.3.3/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/ubuntu-xenial xenial main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.3~0xenial

--- a/xenial/2.3.4/Dockerfile
+++ b/xenial/2.3.4/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/ubuntu-xenial xenial main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.4~0xenial

--- a/xenial/2.3.5/Dockerfile
+++ b/xenial/2.3.5/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Daniel Alan Miller <dalanmiller@rethinkdb.com>
 
 # Add the RethinkDB repository and public key
 # "RethinkDB Packaging <packaging@rethinkdb.com>" https://download.rethinkdb.com/repository/raw/pubkey.gpg
-RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F"
 RUN echo "deb https://download.rethinkdb.com/repository/ubuntu-xenial xenial main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.5~0xenial

--- a/xenial/2.3.6/Dockerfile
+++ b/xenial/2.3.6/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -qqy \
     && apt-get install -y --no-install-recommends apt-transport-https ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1D85E93F801BB43F \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1D85E93F801BB43F \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-xenial xenial main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.3.6~0xenial

--- a/xenial/2.4.0/Dockerfile
+++ b/xenial/2.4.0/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-xenial xenial main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0xenial

--- a/xenial/2.4.1/Dockerfile
+++ b/xenial/2.4.1/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
     && echo "deb https://download.rethinkdb.com/repository/ubuntu-xenial xenial main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.1~0xenial


### PR DESCRIPTION
**Reason for the change**
Keyservers are broken or deprecated. Replace them with Ubuntu's keyserver.

**Description**
This PR replaces all Dockerfile's keyserver with Ubuntu's keyserver

**Code examples**
N/A

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**

* https://github.com/rethinkdb/rethinkdb/issues/6991#issuecomment-948273284
