### PR TITLE
Update bullseye to use a full key fingerprint

### DIFF
--- a/bullseye/2.4.2/Dockerfile
+++ b/bullseye/2.4.2/Dockerfile
@@ -4,7 +4,10 @@ RUN apt-get -qqy update \
     && apt-get install -y --no-install-recommends ca-certificates gnupg2 curl \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://download.rethinkdb.com/repository/raw/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/rethinkdb.gpg | gpg --armor \
+RUN GNUPGHOME="$(mktemp -d)" && export GNUPGHOME \
+    && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 539A3A8C6692E6E3F69B3FE81D85E93F801BB43F \
+    && gpg --batch --export 539A3A8C6692E6E3F69B3FE81D85E93F801BB43F > /usr/share/keyrings/rethinkdb.gpg \
+    && gpgconf --kill all && rm -rf "$GNUPGHOME" \
     && echo "deb [signed-by=/usr/share/keyrings/rethinkdb.gpg] https://download.rethinkdb.com/repository/debian-bullseye bullseye main" > /etc/apt/sources.list.d/rethinkdb.list
 
 ENV RETHINKDB_PACKAGE_VERSION 2.4.2~0bullseye


### PR DESCRIPTION
**Reason for the change**
https://github.com/docker-library/official-images/pull/12389#issuecomment-1121401157

**Description**
This allows GnuPG to do additional verification that the key fetched matches the full fingerprint (a cryptographic checksum of the key).

**Code examples**
https://github.com/docker-library/mysql/blob/68bc91b85ffde4ec9c0ca084b092acfb28463bfa/8.0/Dockerfile.debian#L54-L67

I'm happy to update this across more versions/variants, but figured I'd start with just the bullseye version (since that's what's in https://github.com/docker-library/official-images/pull/12389).