### PR TITLE
Chore: reduce attack surface and size for Docker image

### DIFF
--- a/buster/2.4.1/Dockerfile
+++ b/buster/2.4.1/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D8
 ENV RETHINKDB_PACKAGE_VERSION 2.4.1~0buster
 
 RUN apt-get -qqy update \
-	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& apt-get install -y --no-install-recommends rethinkdb=$RETHINKDB_PACKAGE_VERSION \
 	&& rm -rf /var/lib/apt/lists/*
 
 VOLUME ["/data"]


### PR DESCRIPTION
Hi,

This pull request includes a small improvement for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

In detail:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. Not only can this change trim your image size but it also can also reduce the attack surface.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)