### PR TITLE
2.4.4 dockerfiles, including Ubuntu mantic

### DIFF
--- a/alma8/2.4.4/aarch64/Dockerfile
+++ b/alma8/2.4.4/aarch64/Dockerfile
@@ -1,0 +1,22 @@
+FROM almalinux:8
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4
+
+RUN echo $'[rethinkdb]\n\
+name=RethinkDB\n\
+enabled=1\n\
+baseurl=https://download.rethinkdb.com/repository/alma/8/aarch64/\n\
+gpgkey=https://download.rethinkdb.com/repository/raw/pubkey.gpg\n\
+gpgcheck=1\n' >> /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/alma8/2.4.4/x86_64/Dockerfile
+++ b/alma8/2.4.4/x86_64/Dockerfile
@@ -1,0 +1,22 @@
+FROM almalinux:8
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4
+
+RUN echo $'[rethinkdb]\n\
+name=RethinkDB\n\
+enabled=1\n\
+baseurl=https://download.rethinkdb.com/repository/alma/8/x86_64/\n\
+gpgkey=https://download.rethinkdb.com/repository/raw/pubkey.gpg\n\
+gpgcheck=1\n' >> /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/alma9/2.4.4/aarch64/Dockerfile
+++ b/alma9/2.4.4/aarch64/Dockerfile
@@ -1,0 +1,22 @@
+FROM almalinux:9
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4
+
+RUN echo $'[rethinkdb]\n\
+name=RethinkDB\n\
+enabled=1\n\
+baseurl=https://download.rethinkdb.com/repository/alma/9/aarch64/\n\
+gpgkey=https://download.rethinkdb.com/repository/raw/pubkey.gpg\n\
+gpgcheck=1\n' >> /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/alma9/2.4.4/x86_64/Dockerfile
+++ b/alma9/2.4.4/x86_64/Dockerfile
@@ -1,0 +1,22 @@
+FROM almalinux:9
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4
+
+RUN echo $'[rethinkdb]\n\
+name=RethinkDB\n\
+enabled=1\n\
+baseurl=https://download.rethinkdb.com/repository/alma/9/x86_64/\n\
+gpgkey=https://download.rethinkdb.com/repository/raw/pubkey.gpg\n\
+gpgcheck=1\n' >> /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/bionic/2.4.4/Dockerfile
+++ b/bionic/2.4.4/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:bionic
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+    && echo "deb https://download.rethinkdb.com/repository/ubuntu-bionic bionic main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0bionic
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080

--- a/bookworm/2.4.4/Dockerfile
+++ b/bookworm/2.4.4/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:bookworm-slim
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends ca-certificates gnupg2 curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN GNUPGHOME="$(mktemp -d)" && export GNUPGHOME \
+    && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 539A3A8C6692E6E3F69B3FE81D85E93F801BB43F \
+    && gpg --batch --export 539A3A8C6692E6E3F69B3FE81D85E93F801BB43F > /usr/share/keyrings/rethinkdb.gpg \
+    && gpgconf --kill all && rm -rf "$GNUPGHOME" \
+    && echo "deb [signed-by=/usr/share/keyrings/rethinkdb.gpg] https://download.rethinkdb.com/repository/debian-bookworm bookworm main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0bookworm
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080
+

--- a/bullseye/2.4.4/Dockerfile
+++ b/bullseye/2.4.4/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:bullseye-slim
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends ca-certificates gnupg2 curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN GNUPGHOME="$(mktemp -d)" && export GNUPGHOME \
+    && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 539A3A8C6692E6E3F69B3FE81D85E93F801BB43F \
+    && gpg --batch --export 539A3A8C6692E6E3F69B3FE81D85E93F801BB43F > /usr/share/keyrings/rethinkdb.gpg \
+    && gpgconf --kill all && rm -rf "$GNUPGHOME" \
+    && echo "deb [signed-by=/usr/share/keyrings/rethinkdb.gpg] https://download.rethinkdb.com/repository/debian-bullseye bullseye main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0bullseye
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080
+

--- a/buster/2.4.4/Dockerfile
+++ b/buster/2.4.4/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:buster-slim
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN GNUPGHOME="$(mktemp -d)" && export GNUPGHOME \
+    && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys 539A3A8C6692E6E3F69B3FE81D85E93F801BB43F \
+    && gpg --batch --export 539A3A8C6692E6E3F69B3FE81D85E93F801BB43F > /usr/share/keyrings/rethinkdb.gpg \
+    && gpgconf --kill all && rm -rf "$GNUPGHOME" \
+    && echo "deb [signed-by=/usr/share/keyrings/rethinkdb.gpg] https://download.rethinkdb.com/repository/debian-buster buster main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0buster
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080

--- a/centos7/2.4.4/aarch64/Dockerfile
+++ b/centos7/2.4.4/aarch64/Dockerfile
@@ -1,0 +1,22 @@
+FROM centos:7
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4
+
+RUN echo $'[rethinkdb]\n\
+name=RethinkDB\n\
+enabled=1\n\
+baseurl=https://download.rethinkdb.com/repository/centos/7/aarch64/\n\
+gpgkey=https://download.rethinkdb.com/repository/raw/pubkey.gpg\n\
+gpgcheck=1\n' >> /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/cut-new-release.sh
+++ b/cut-new-release.sh
@@ -1,11 +1,11 @@
 #! /usr/bin/env bash
 
-BASE_VERSION=2.4.3
+BASE_VERSION=2.4.4
 NEW_VERSION=$1
 SUFFIX=$2
 
 # packages for them to downloads.rethinkdb.com
-DISTROS="alma8 alma9 bionic bookworm bullseye buster centos7 focal hirsute impish jammy lunar jessie rocky8 rocky9 stretch trusty xenial"
+DISTROS="alma8 alma9 bionic bookworm bullseye buster centos7 focal hirsute impish jammy jessie lunar mantic rocky8 rocky9 stretch trusty xenial"
 
 function bootstrap_and_build {
   for DISTRO in $DISTROS; do

--- a/focal/2.4.4/Dockerfile
+++ b/focal/2.4.4/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:focal
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+    && echo "deb https://download.rethinkdb.com/repository/ubuntu-focal focal main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0focal
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080

--- a/hirsute/2.4.4/Dockerfile
+++ b/hirsute/2.4.4/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:hirsute
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://download.rethinkdb.com/repository/raw/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/rethinkdb.gpg | gpg --armor \
+    && echo "deb [signed-by=/usr/share/keyrings/rethinkdb.gpg] https://download.rethinkdb.com/repository/ubuntu-hirsute hirsute main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0hirsute
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080
+

--- a/impish/2.4.4/Dockerfile
+++ b/impish/2.4.4/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:impish
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://download.rethinkdb.com/repository/raw/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/rethinkdb.gpg | gpg --armor \
+    && echo "deb [signed-by=/usr/share/keyrings/rethinkdb.gpg] https://download.rethinkdb.com/repository/ubuntu-impish impish main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0impish
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080
+

--- a/jammy/2.4.4/Dockerfile
+++ b/jammy/2.4.4/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:jammy
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://download.rethinkdb.com/repository/raw/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/rethinkdb.gpg | gpg --armor \
+    && echo "deb [signed-by=/usr/share/keyrings/rethinkdb.gpg] https://download.rethinkdb.com/repository/ubuntu-jammy jammy main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0jammy
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080
+

--- a/jessie/2.4.4/Dockerfile
+++ b/jessie/2.4.4/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:jessie-slim
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+    && echo "deb https://download.rethinkdb.com/repository/debian-jessie jessie main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0jessie
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080
+

--- a/lunar/2.4.4/Dockerfile
+++ b/lunar/2.4.4/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:lunar
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://download.rethinkdb.com/repository/raw/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/rethinkdb.gpg | gpg --armor \
+    && echo "deb [signed-by=/usr/share/keyrings/rethinkdb.gpg] https://download.rethinkdb.com/repository/ubuntu-lunar lunar main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0lunar
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080
+

--- a/mantic/2.4.4/Dockerfile
+++ b/mantic/2.4.4/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:mantic
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://download.rethinkdb.com/repository/raw/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/rethinkdb.gpg | gpg --armor \
+    && echo "deb [signed-by=/usr/share/keyrings/rethinkdb.gpg] https://download.rethinkdb.com/repository/ubuntu-mantic mantic main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0mantic
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080
+

--- a/rocky8/2.4.4/aarch64/Dockerfile
+++ b/rocky8/2.4.4/aarch64/Dockerfile
@@ -1,0 +1,22 @@
+FROM rockylinux:8
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4
+
+RUN echo $'[rethinkdb]\n\
+name=RethinkDB\n\
+enabled=1\n\
+baseurl=https://download.rethinkdb.com/repository/rocky/8/aarch64/\n\
+gpgkey=https://download.rethinkdb.com/repository/raw/pubkey.gpg\n\
+gpgcheck=1\n' >> /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/rocky8/2.4.4/x86_64/Dockerfile
+++ b/rocky8/2.4.4/x86_64/Dockerfile
@@ -1,0 +1,22 @@
+FROM rockylinux:8
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4
+
+RUN echo $'[rethinkdb]\n\
+name=RethinkDB\n\
+enabled=1\n\
+baseurl=https://download.rethinkdb.com/repository/rocky/8/x86_64/\n\
+gpgkey=https://download.rethinkdb.com/repository/raw/pubkey.gpg\n\
+gpgcheck=1\n' >> /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/rocky9/2.4.4/aarch64/Dockerfile
+++ b/rocky9/2.4.4/aarch64/Dockerfile
@@ -1,0 +1,22 @@
+FROM rockylinux:9
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4
+
+RUN echo $'[rethinkdb]\n\
+name=RethinkDB\n\
+enabled=1\n\
+baseurl=https://download.rethinkdb.com/repository/rocky/9/aarch64/\n\
+gpgkey=https://download.rethinkdb.com/repository/raw/pubkey.gpg\n\
+gpgcheck=1\n' >> /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/rocky9/2.4.4/x86_64/Dockerfile
+++ b/rocky9/2.4.4/x86_64/Dockerfile
@@ -1,0 +1,22 @@
+FROM rockylinux:9
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4
+
+RUN echo $'[rethinkdb]\n\
+name=RethinkDB\n\
+enabled=1\n\
+baseurl=https://download.rethinkdb.com/repository/rocky/9/x86_64/\n\
+gpgkey=https://download.rethinkdb.com/repository/raw/pubkey.gpg\n\
+gpgcheck=1\n' >> /etc/yum.repos.d/rethinkdb.repo
+
+RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION \
+	&& yum clean all
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+# process cluster webui
+EXPOSE 28015 29015 8080

--- a/stretch/2.4.4/Dockerfile
+++ b/stretch/2.4.4/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:stretch-slim
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends apt-transport-https dirmngr ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --keyserver pgp.mit.edu --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+    && echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0stretch
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080

--- a/trusty/2.4.4/Dockerfile
+++ b/trusty/2.4.4/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:trusty
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+    && echo "deb https://download.rethinkdb.com/repository/ubuntu-trusty trusty main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0trusty
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080

--- a/xenial/2.4.4/Dockerfile
+++ b/xenial/2.4.4/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:xenial
+
+RUN apt-get -qqy update \
+    && apt-get install -y --no-install-recommends apt-transport-https ca-certificates gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "539A3A8C6692E6E3F69B3FE81D85E93F801BB43F" \
+    && echo "deb https://download.rethinkdb.com/repository/ubuntu-xenial xenial main" > /etc/apt/sources.list.d/rethinkdb.list
+
+ENV RETHINKDB_PACKAGE_VERSION 2.4.4~0xenial
+
+RUN apt-get -qqy update \
+	&& apt-get install -y rethinkdb=$RETHINKDB_PACKAGE_VERSION \
+	&& rm -rf /var/lib/apt/lists/*
+
+VOLUME ["/data"]
+
+WORKDIR /data
+
+CMD ["rethinkdb", "--bind", "all"]
+
+#   process cluster webui
+EXPOSE 28015 29015 8080


### PR DESCRIPTION
Also updates cut-new-release.sh with Ubuntu mantic, and, as is necessary (because only 2.4.4 supports Ubuntu mantic), with BASE_VERSION=2.4.4.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
